### PR TITLE
Inject SKATE_NODE_NAME in pods

### DIFF
--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -348,8 +348,8 @@ echo ovs="$(cat /tmp/ovs-$$)";
         let result = self
             .client
             .execute(&format!(
-                "echo '{}'| base64 --decode|sudo skatelet apply -",
-                base64_manifest
+                "echo '{}'| base64 --decode|sudo skatelet apply --node-name {} -",
+                base64_manifest, self.node_name
             ))
             .await?;
         match result.exit_status {


### PR DESCRIPTION
Hack to get new coredns gathersrv to work. Real fix is to support valueFrom: spec.nodeName